### PR TITLE
Use refactored ropt plugin code

### DIFF
--- a/everest/suite.py
+++ b/everest/suite.py
@@ -24,7 +24,7 @@ from seba_sqlite import SqliteStorage
 import everest
 from everest.config import EverestConfig
 from everest.optimizer.everest2ropt import everest2ropt
-from everest.optimizer.ropt_plugins import EverestPlanStepBackend
+from everest.optimizer.ropt_plugins import EverestPlanStepPlugin
 from everest.optimizer.utils import get_ropt_plugin_manager
 from everest.plugins.site_config_env import PluginSiteConfigEnv
 from everest.simulator import Simulator
@@ -404,9 +404,9 @@ class _EverestWorkflow(object):
         simulator = Simulator(self.config, callback=self._simulation_callback)
 
         plugin_manager = get_ropt_plugin_manager()
-        plugin_manager.add_backends(
+        plugin_manager.add_plugins(
             "optimization_step",
-            {EverestPlanStepBackend.BACKEND_NAME: EverestPlanStepBackend(self.config)},
+            {"everest": EverestPlanStepPlugin(self.config)},
         )
         optimizer = EnsembleOptimizer(
             evaluator=simulator, plugin_manager=plugin_manager
@@ -565,8 +565,6 @@ class _EverestWorkflow(object):
         for step in plan:
             if "ensemble_evaluation" in step:
                 have_ensemble_evaluation = True
-            if EverestPlanStepBackend.supported(step):
-                step["backend"] = EverestPlanStepBackend.BACKEND_NAME
         return plan, have_ensemble_evaluation
 
     def _init_evaluation_reporter(self, optimizer, ropt_output_folder):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
     "PyQt5",
     "colorama",
     "numpy<2",
-    "ropt[pandas]<0.3",
-    "ropt-dakota<0.3",
+    "ropt[pandas]<0.4",
+    "ropt-dakota<0.4",
     "seba-sqlite",
     "setuptools; python_version >= '3.12'",
 ]

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -31,19 +31,11 @@ def all_errors(error: ValidationError, match: str):
     return instances
 
 
-def test_that_sampler_config_with_missing_backend():
-    with pytest.raises(ValueError) as e:
-        SamplerConfig(backend="scipssy", method="hey")
-
-    assert has_error(e.value, match="Backend scipssy not found(.*)")
-    assert not has_error(e.value, match="Method (.*) not found")
-
-
 def test_that_sampler_config_with_wrong_method():
     with pytest.raises(ValueError) as e:
         SamplerConfig(backend="scipy", method="hey")
 
-    assert has_error(e.value, match="Method (.*) not found")
+    assert has_error(e.value, match="Sampler (.*) not found")
 
 
 def test_that_duplicate_well_names_raise_error():
@@ -446,22 +438,11 @@ def test_that_model_realizations_weights_must_correspond_to_realizations():
     )
 
 
-def test_that_missing_optimization_backend_errors():
-    with pytest.raises(ValueError) as e:
-        EverestConfig.with_defaults(**{"optimization": {"backend": "dakotta"}})
-
-    assert has_error(e.value, match="Backend dakotta not found")
-
-    EverestConfig.with_defaults(
-        **{"optimization": {"backend": "scipy", "algorithm": "newton-CG"}}
-    )
-
-
 def test_that_missing_optimization_algorithm_errors():
     with pytest.raises(ValueError) as e:
         EverestConfig.with_defaults(**{"optimization": {"algorithm": "ddlygldt"}})
 
-    assert has_error(e.value, match="Algorithm 'ddlygldt' not found for optimizer")
+    assert has_error(e.value, match="Optimizer algorithm 'dakota/ddlygldt' not found")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_repo_configs.py
+++ b/tests/test_repo_configs.py
@@ -43,7 +43,7 @@ def test_all_repo_configs():
     if os.environ.get("NO_PROJECT_RES", False):
         config_files = [f for f in config_files if "examples/egg" not in f]
     try:
-        get_ropt_plugin_manager().get_backend("optimizer", "scipy")
+        get_ropt_plugin_manager().get_plugin("optimizer", "scipy/default")
     except ROptConfigError:
         config_files = [f for f in config_files if "scipy" not in f]
 

--- a/tests/test_seba_initialization.py
+++ b/tests/test_seba_initialization.py
@@ -149,7 +149,7 @@ def test_everest2ropt_controls_optimizer_setting():
     config = EverestConfig.load_file(config)
     ropt_config = EnOptConfig.model_validate(everest2ropt(config))
     assert len(ropt_config.realizations.names) == 15
-    assert ropt_config.optimizer.algorithm == "conmin_mfd"
+    assert ropt_config.optimizer.method == "dakota/conmin_mfd"
     assert ropt_config.gradient.number_of_perturbations == 20
     assert ropt_config.realizations.names == tuple(range(15))
 
@@ -171,7 +171,6 @@ def test_everest2ropt_backend_options():
 
     config.optimization.options = ["test = 1"]
     ropt_config = EnOptConfig.model_validate(everest2ropt(config))
-    assert ropt_config.optimizer.backend == "dakota"
     assert ropt_config.optimizer.options == ["test = 1"]
 
     config.optimization.backend = "scipy"
@@ -181,7 +180,6 @@ def test_everest2ropt_backend_options():
 
     config.optimization.options = None
     ropt_config = EnOptConfig.model_validate(everest2ropt(config))
-    assert ropt_config.optimizer.backend == "scipy"
     assert ropt_config.optimizer.options["test"] == 1
 
 
@@ -194,11 +192,11 @@ def test_everest2ropt_samplers():
 
     assert len(ropt_config.samplers) == 5
     assert ropt_config.gradient.samplers.tolist() == [0, 0, 1, 2, 3, 4]
-    assert ropt_config.samplers[0].method == "norm"
-    assert ropt_config.samplers[1].method == "norm"
-    assert ropt_config.samplers[2].method == "uniform"
-    assert ropt_config.samplers[3].method == "norm"
-    assert ropt_config.samplers[4].method == "uniform"
+    assert ropt_config.samplers[0].method == "scipy/norm"
+    assert ropt_config.samplers[1].method == "scipy/norm"
+    assert ropt_config.samplers[2].method == "scipy/uniform"
+    assert ropt_config.samplers[3].method == "scipy/norm"
+    assert ropt_config.samplers[4].method == "scipy/uniform"
     for idx in range(5):
         if idx == 1:
             assert ropt_config.samplers[idx].shared
@@ -272,4 +270,4 @@ def test_everest2ropt_no_algorithm_name():
 
     config.optimization.algorithm = None
     ropt_config = EnOptConfig.model_validate(everest2ropt(config))
-    assert ropt_config.optimizer.algorithm is None
+    assert ropt_config.optimizer.method == "dakota/default"


### PR DESCRIPTION
**Issue**
The handling of plugins in `ropt` has changed. The main advantage it is not necessary to specify the name of the backend anymore when configuring an optimizer or a sampler. This means that in principle the `backend` keywords could be removed from the Everest configuration, simplifying configuration for users. I addition, the code in Everest has become slightly more simple.

This PR updates Everest to use the new `ropt` code, but retains for now the exact behavior as before, i.e. the `backend` keywords is still needed or set by default to `dakota`. I suggest that we revisit the `backend` keyword in the Everest configuration at a later point and possibly remove it (see issue #4)
