### PR TITLE
Pin ropt dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
     "PyQt5",
     "colorama",
     "numpy<2",
-    "ropt[pandas]>=0.2.1",
-    "ropt-dakota>=0.2",
+    "ropt[pandas]<0.3",
+    "ropt-dakota<0.3",
     "seba-sqlite",
     "setuptools; python_version >= '3.12'",
 ]


### PR DESCRIPTION
**Issue**
We running into issues with `ropt` being bumped on PyPI, while Everest is not updated yet. This PR pins the version be lower than the first incompatible version.
