### PR TITLE
Avoid setting requirements using a beta tag of Ert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pluggy",
     "decorator",
     "resdata",
-    "ert>=10.1.0b0",
+    "ert>=10.1.1",
     "PyQt5",
     "colorama",
     "numpy<2",


### PR DESCRIPTION
We should not use a beta tag as a requirement
