### PR TITLE
Extend ert queue options with everest options instead of overwriting all

### DIFF
--- a/everest/detached/__init__.py
+++ b/everest/detached/__init__.py
@@ -503,7 +503,7 @@ def generate_everserver_ert_config(config: EverestConfig, debug_mode: bool = Fal
             queue_system,
         )
         if queue_options:
-            everserver_config["QUEUE_OPTION"] = queue_options
+            everserver_config.setdefault("QUEUE_OPTION", []).extend(queue_options)
     else:
         everserver_config["QUEUE_SYSTEM"] = queue_system
 

--- a/everest/queue_driver/queue_driver.py
+++ b/everest/queue_driver/queue_driver.py
@@ -1,7 +1,6 @@
 from typing import Any, List, Optional, Tuple
 
 from ert.config import QueueSystem
-
 from everest.config import EverestConfig
 from everest.config.simulator_config import SimulatorConfig
 from everest.config_keys import ConfigKeys
@@ -58,16 +57,13 @@ def _extract_ert_queue_options_from_simulator_config(
     )
 
 
-def extract_queue_system(ever_config: EverestConfig):
+def _extract_queue_system(ever_config: EverestConfig, ert_config):
     queue_system = (
         ever_config.simulator.queue_system if ever_config.simulator else None
     ) or "local"
-
-    queue = {
-        "QUEUE_SYSTEM": QueueSystem(queue_system.upper()),
-        "QUEUE_OPTION": _extract_ert_queue_options_from_simulator_config(
+    ert_config["QUEUE_SYSTEM"] = QueueSystem(queue_system.upper())
+    ert_config.setdefault("QUEUE_OPTION", []).extend(
+        _extract_ert_queue_options_from_simulator_config(
             ever_config.simulator, queue_system
-        ),
-    }
-
-    return queue
+        )
+    )

--- a/everest/simulator/everest2res.py
+++ b/everest/simulator/everest2res.py
@@ -11,7 +11,7 @@ from everest.config.install_data_config import InstallDataConfig
 from everest.config.install_job_config import InstallJobConfig
 from everest.config.simulator_config import SimulatorConfig
 from everest.config_keys import ConfigKeys
-from everest.queue_driver.queue_driver import extract_queue_system
+from everest.queue_driver.queue_driver import _extract_queue_system
 from everest.strings import EVEREST, SIMULATION_DIR, STORAGE_DIR
 from everest.util.forward_models import collect_forward_models
 
@@ -481,7 +481,7 @@ def everest2res(ever_config: EverestConfig, site_config=None):
     _extract_workflow_jobs(ever_config, ert_config, config_dir)
     _extract_workflows(ever_config, ert_config, config_dir)
     _extract_model(ever_config, ert_config)
-    ert_config.update(extract_queue_system(ever_config))
+    _extract_queue_system(ever_config, ert_config)
     _extract_seed(ever_config, ert_config)
 
     return ert_config

--- a/tests/test_detached.py
+++ b/tests/test_detached.py
@@ -252,8 +252,14 @@ def test_everserver_queue_config_equal_to_run_config(queue_system, cores, name):
     run_queue_option = ert_config["QUEUE_OPTION"]
 
     assert ert_config["QUEUE_SYSTEM"] == server_ert_config["QUEUE_SYSTEM"]
-    assert next(filter(lambda x: "MAX_RUNNING" in x, run_queue_option))[-1] == cores
-    assert next(filter(lambda x: "MAX_RUNNING" in x, server_queue_option))[-1] == 1
+    assert (
+        next(filter(lambda x: "MAX_RUNNING" in x, reversed(run_queue_option)))[-1]
+        == cores
+    )
+    assert (
+        next(filter(lambda x: "MAX_RUNNING" in x, reversed(server_queue_option)))[-1]
+        == 1
+    )
     if name is not None:
         assert next(filter(lambda x: name in x, run_queue_option)) == next(
             filter(lambda x: name in x, server_queue_option)
@@ -278,7 +284,7 @@ def test_detached_mode_config_only_sim(queue_system):
 
     reference["QUEUE_SYSTEM"] = queue_system.upper()
     queue_options = [(queue_system.upper(), "MAX_RUNNING", 1)]
-    reference["QUEUE_OPTION"] = queue_options
+    reference.setdefault("QUEUE_OPTION", []).extend(queue_options)
     everest_config.simulator = SimulatorConfig(**{CK.QUEUE_SYSTEM: queue_system})
     ert_config = generate_everserver_ert_config(everest_config)
     assert ert_config is not None
@@ -306,7 +312,7 @@ def test_detached_mode_config_queue_name():
     reference["QUEUE_SYSTEM"] = QueueSystem.LSF
     queue_options = [(QueueSystem.LSF, "LSF_QUEUE", queue_name)]
 
-    reference["QUEUE_OPTION"] = queue_options
+    reference.setdefault("QUEUE_OPTION", []).extend(queue_options)
     everest_config.simulator = SimulatorConfig(queue_system="lsf")
     everest_config.server = ServerConfig(queue_system="lsf", name=queue_name)
 

--- a/tests/test_queue_driver.py
+++ b/tests/test_queue_driver.py
@@ -1,10 +1,9 @@
 from unittest.mock import Mock
 
 import pytest
-
 from everest.config import EverestConfig
 from everest.queue_driver import queue_driver
-from everest.queue_driver.queue_driver import extract_queue_system
+from everest.queue_driver.queue_driver import _extract_queue_system
 
 
 @pytest.mark.parametrize(
@@ -34,5 +33,7 @@ def test_extract_queue_system(monkeypatch, input_config, queue_system, expected_
         "_extract_ert_queue_options_from_simulator_config",
         extract_options_mock,
     )
-    assert extract_queue_system(input_config) == expected_result
+    ert_config = {}
+    _extract_queue_system(input_config, ert_config)
+    assert ert_config == expected_result
     extract_options_mock.assert_called_once_with(input_config.simulator, queue_system)


### PR DESCRIPTION
**Issue**
Everest discards the queue options from site config. 

Closes #16 


**Approach**
This appends the everest queue options to the site config options, trusting ert to correctly prioritize the latest options.
