### PR TITLE
Lessen dependency on ert config if not needed

### DIFF
--- a/everest/api/everest_data_api.py
+++ b/everest/api/everest_data_api.py
@@ -1,13 +1,11 @@
 from collections import OrderedDict
 
 import pandas as pd
-from ert.config import ErtConfig
 from ert.storage import open_storage
 from seba_sqlite.snapshot import SebaSnapshot
 
 from everest.config import EverestConfig
 from everest.detached import ServerStatus, everserver_status
-from everest.simulator.everest2res import everest2res
 
 
 class EverestDataAPI:
@@ -157,13 +155,8 @@ class EverestDataAPI:
         if batches is None:
             batches = self.batches
         simulations = self.simulations
-        ert_config = ErtConfig.from_dict(
-            config_dict=everest2res(
-                self._config, site_config=ErtConfig.read_site_config()
-            )
-        )
         data_frames = []
-        storage = open_storage(ert_config.ens_path, "r")
+        storage = open_storage(self._config.storage_dir, "r")
         for batch_id in batches:
             summary = storage.get_ensemble_by_name(
                 f"batch_{batch_id}"

--- a/everest/bin/everload_script.py
+++ b/everest/bin/everload_script.py
@@ -153,9 +153,8 @@ def reload_data(ever_config: EverestConfig, backup_path=None):
     ever_config.install_templates = None
 
     # prepare the ErtConfig object
-    ert_config = everest2res(ever_config, site_config=ErtConfig.read_site_config())
-    orig_path = ert_config["ENSPATH"]
-    ert_config = ErtConfig.from_dict(config_dict=ert_config)
+    ert_config_dict = everest2res(ever_config, site_config=ErtConfig.read_site_config())
+    ert_config = ErtConfig.from_dict(config_dict=ert_config_dict)
 
     # load information about batches from previous run
     df = export(ever_config, export_ecl=False)
@@ -163,9 +162,9 @@ def reload_data(ever_config: EverestConfig, backup_path=None):
 
     # backup or delete the previous internal storage
     if backup_path:
-        shutil.move(orig_path, backup_path)
+        shutil.move(ever_config.storage_dir, backup_path)
     else:
-        shutil.rmtree(orig_path)
+        shutil.rmtree(ever_config.storage_dir)
 
     # internalize one batch at a time
     for batch_id, group in groups:

--- a/everest/export.py
+++ b/everest/export.py
@@ -4,13 +4,11 @@ import sys
 from typing import Any, Dict, List, Optional, Set
 
 import pandas as pd
-from ert.config import ErtConfig
 from ert.storage import open_storage
 from pandas import DataFrame
 from seba_sqlite.snapshot import SebaSnapshot
 
 from everest.config import EverestConfig
-from everest.simulator.everest2res import everest2res
 from everest.strings import STORAGE_DIR
 
 if sys.version_info < (3, 11):
@@ -157,15 +155,11 @@ def _metadata(config: EverestConfig):
 
 
 def get_internalized_keys(config: EverestConfig, batch_ids: Optional[Set[int]] = None):
-    ert_config = ErtConfig.from_dict(
-        everest2res(config, site_config=ErtConfig.read_site_config())
-    )
     if batch_ids is None:
         metadata = _metadata(config)
         batch_ids = {data[MetaDataColumnNames.BATCH] for data in metadata}
-
     internal_keys: Set = set()
-    with open_storage(ert_config.ens_path, "r") as storage:
+    with open_storage(config.storage_dir, "r") as storage:
         for batch_id in batch_ids:
             ensemble = storage.get_ensemble_by_name("batch_{}".format(batch_id))
             if not internal_keys:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -433,9 +433,7 @@ def test_ropt_integration(mock_get_optimization_output_dir):
 
 
 @patch("everest.api.everest_data_api.open_storage", return_value=mock_storage((0, 2)))
-@patch("everest.api.everest_data_api.ErtConfig", return_value=None)
-@patch("everest.api.everest_data_api.everest2res", return_value=None)
-def test_get_summary_keys(_, _1, _2, api_no_gradient):
+def test_get_summary_keys(_, api_no_gradient):
     # Retrieve the pandas data frame with mocked values.
     summary_values = api_no_gradient.summary_values()
     # Check some data frame properties.
@@ -460,9 +458,7 @@ def test_get_summary_keys(_, _1, _2, api_no_gradient):
 
 
 @patch("everest.api.everest_data_api.open_storage", return_value=mock_storage((0, 2)))
-@patch("everest.api.everest_data_api.ErtConfig", return_value=None)
-@patch("everest.api.everest_data_api.everest2res", return_value=None)
-def test_get_summary_keys_gradient(_, _1, _2, api):
+def test_get_summary_keys_gradient(_, api):
     # Retrieve the pandas data frame with mocked values.
     summary_values = api.summary_values()
     # Check some data frame properties.
@@ -486,9 +482,7 @@ def test_get_summary_keys_gradient(_, _1, _2, api):
 
 
 @patch("everest.api.everest_data_api.open_storage", return_value=mock_storage([2]))
-@patch("everest.api.everest_data_api.ErtConfig", return_value=None)
-@patch("everest.api.everest_data_api.everest2res", return_value=None)
-def test_get_summary_keys_single_batch(_, _1, _2, api_no_gradient):
+def test_get_summary_keys_single_batch(_, api_no_gradient):
     # Retrieve the pandas data frame with mocked values.
     summary_values = api_no_gradient.summary_values(batches=[2])
     # Check some data frame properties.
@@ -514,9 +508,7 @@ def test_get_summary_keys_single_batch(_, _1, _2, api_no_gradient):
 
 
 @patch("everest.api.everest_data_api.open_storage", return_value=mock_storage((0, 2)))
-@patch("everest.api.everest_data_api.ErtConfig", return_value=None)
-@patch("everest.api.everest_data_api.everest2res", return_value=None)
-def test_get_summary_keys_single_key(_, _1, _2, api_no_gradient):
+def test_get_summary_keys_single_key(_, api_no_gradient):
     # Retrieve the pandas data frame with mocked values.
     summary_values = api_no_gradient.summary_values(keys=["key2"])
     # Check some data frame properties.


### PR DESCRIPTION
**Issue**

There are instances where we make an ErtConfig just to get access to `ENSPATH` that is already set in an everest config.

**Approach**
Avoid creating ErtConfig objects if they are not used to start a froward model run 