### PR TITLE
Handle case for no local DNS more properly

### DIFF
--- a/everest/detached/jobs/everserver.py
+++ b/everest/detached/jobs/everserver.py
@@ -53,7 +53,7 @@ def get_machine_name():
         ]
         resolved_hosts.sort()
         return resolved_hosts[0]
-    except resolver.NXDOMAIN:
+    except (resolver.NXDOMAIN, resolver.NoResolverConfiguration):
         # If local address and reverse lookup not working - fallback
         # to socket fqdn which are using /etc/hosts to retrieve this name
         return socket.getfqdn()


### PR DESCRIPTION
This exception has been observed on a system where DNS is configured strangely. The fallback as this change directs to makes it work fine.

**Issue**

```
$ (main) everest run config.yml
Waiting for server ...
Failed to start Everest with error:
Traceback (most recent call last):
  File "/home/berland/projects/everest/everest/detached/jobs/everserver.py", line 242, in main
    cert_path, key_path, key_pw = _generate_certificate(config)
  File "/home/berland/projects/everest/everest/detached/jobs/everserver.py", line 368, in _generate_certificate
    cert_name = get_machine_name()
  File "/home/berland/projects/everest/everest/detached/jobs/everserver.py", line 54, in get_machine_name
    for ptr_record in resolver.resolve(reverse_name, "PTR")
  File "/home/berland/venv/jun24/lib/python3.10/site-packages/dns/resolver.py", line 1565, in resolve
    return get_default_resolver().resolve(
  File "/home/berland/venv/jun24/lib/python3.10/site-packages/dns/resolver.py", line 1529, in get_default_resolver
    reset_default_resolver()
  File "/home/berland/venv/jun24/lib/python3.10/site-packages/dns/resolver.py", line 1542, in reset_default_resolver
    default_resolver = Resolver()
  File "/home/berland/venv/jun24/lib/python3.10/site-packages/dns/resolver.py", line 944, in __init__
    self.read_resolv_conf(filename)
  File "/home/berland/venv/jun24/lib/python3.10/site-packages/dns/resolver.py", line 1038, in read_resolv_conf
    raise NoResolverConfiguration("no nameservers")
dns.resolver.NoResolverConfiguration: no nameservers
```


where `reverse_name=<DNS name 20.1.168.192.in-addr.arpa.>
`

**Approach**
Catch and fallback.