### PR TITLE
Fix typo successfully

### DIFF
--- a/everest/strings.py
+++ b/everest/strings.py
@@ -17,7 +17,7 @@ OPTIMIZATION_LOG_DIR = "logs"
 OPT_PROGRESS_ENDPOINT = "opt_progress"
 OPT_PROGRESS_ID = "optimization_progress"
 OPT_FAILURE_REALIZATIONS = (
-    "Optimization failed: not enough succesful realizations to proceed."
+    "Optimization failed: not enough successful realizations to proceed."
 )
 
 SESSION_DIR = ".session"

--- a/everest/util/async_run.py
+++ b/everest/util/async_run.py
@@ -6,7 +6,7 @@ def async_run(function, on_finished=None, on_error=None):
 
     If the function raise an exception, on_error is called, with the
     exception as first argument.
-    When the excecution is finished (either succesfully or with an
+    When the excecution is finished (either successfully or with an
     exception), on_finished is called with:
     - first argument is the value returned by the function
     - second argument is None if the function completed correctly, or


### PR DESCRIPTION
**Issue**
Typo observed in:

```
$ everest run config.yml 
Waiting for server ...
Everest server found!
===================== Running forward models (Batch #0) ======================

  Waiting: 0 | Pending: 0 | Running: 3 | Complete: 0 | FAILED: 3

  well_constraints: 0/6/0 | Success: 0-5
     add_templates: 0/6/0 | Success: 0-5
          schmerge: 0/6/0 | Success: 0-5
        eclipse100: 0/0/6 | Failure: 0-5
       strip_dates: 0/0/0
                rf: 0/0/0

Optimization failed: not enough succesful realizations to proceed.
```

**Approach**
🧹 