### PR TITLE
Adding readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
**Issue**
There is a readthedocs website to deploy the documentation but we're missing the configuration files.
This PR solves it. 

Closes #57 

**Approach**
1. Created the .readthedocs.yml configuration file
2. (_after_ merging) Importing the project to readthedocs

