### PR TITLE
Add tests for QtDialogsOut

### DIFF
--- a/src/ieverest/io/qt_dialogs_output.py
+++ b/src/ieverest/io/qt_dialogs_output.py
@@ -1,4 +1,4 @@
-from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
+from logging import CRITICAL, DEBUG, INFO, WARNING
 
 from qtpy.QtWidgets import QMessageBox
 
@@ -14,10 +14,6 @@ class QtDialogsOut(object):
     def critical(self, message, force=False):
         if self.log_level <= CRITICAL or force:
             QMessageBox.critical(self._main_window, "Critical", message)
-
-    def _error(self, message, force=False):
-        if self.log_level <= ERROR or force:
-            QMessageBox.critical(self._main_window, "Error", message)
 
     def warning(self, message, force=False):
         if self.log_level <= WARNING or force:

--- a/tests/test_qt_dialogs_output.py
+++ b/tests/test_qt_dialogs_output.py
@@ -1,0 +1,61 @@
+import pytest
+from everest.detached import (
+    context_stop_and_wait,
+    wait_for_context,
+)
+from ieverest import IEverest
+from ieverest.utils import APP_OUT_DIALOGS, app_output
+from PyQt5.QtWidgets import QMessageBox
+from qtpy.QtCore import Qt, QTimer
+
+
+@pytest.mark.ui_test
+@pytest.mark.xdist_group(name="starts_everest")
+def test_qt_dialogs(qtbot):
+    wait_for_context()
+
+    ieverest = IEverest()
+
+    def handle_message_box(message):
+        qtbot.waitUntil(lambda: ieverest._gui.findChild(QMessageBox) is not None)
+        widget = ieverest._gui.findChild(QMessageBox)
+        qtbot.mouseClick(widget.button(QMessageBox.Ok), Qt.MouseButton.LeftButton)
+        assert message in widget.text()
+
+    QTimer.singleShot(100, lambda: handle_message_box("info message"))
+    app_output().info(
+        "info message",
+        channels=[
+            APP_OUT_DIALOGS,
+        ],
+        force=True,
+    )
+
+    QTimer.singleShot(100, lambda: handle_message_box("critical message"))
+    app_output().critical(
+        "critical message",
+        channels=[
+            APP_OUT_DIALOGS,
+        ],
+        force=True,
+    )
+
+    QTimer.singleShot(100, lambda: handle_message_box("warning message"))
+    app_output().warning(
+        "warning message",
+        channels=[
+            APP_OUT_DIALOGS,
+        ],
+        force=True,
+    )
+
+    QTimer.singleShot(100, lambda: handle_message_box("debug message"))
+    app_output().debug(
+        "debug message",
+        channels=[
+            APP_OUT_DIALOGS,
+        ],
+        force=True,
+    )
+
+    context_stop_and_wait()


### PR DESCRIPTION
**Issue**
_Short description of the issue_

Closes #93 



```
---------- coverage: platform linux, python 3.10.12-final-0 ----------
Name                                          Stmts   Miss  Cover
-----------------------------------------------------------------
src/ieverest/__init__.py                          3      0   100%
src/ieverest/bin/__init__.py                      0      0   100%
src/ieverest/bin/ieverest_script.py              29     19    34%
src/ieverest/config_widget.py                    17      0   100%
src/ieverest/ieverest.py                        198     70    65%
src/ieverest/io/__init__.py                       4      0   100%
src/ieverest/io/output_dispatcher.py             33      3    91%
-----------------------------------------------------------------
src/ieverest/io/qt_dialogs_output.py             19      0   100%
-----------------------------------------------------------------
src/ieverest/io/qt_status_bar_output.py          25      6    76%
src/ieverest/main_window.py                     128      5    96%
src/ieverest/monitor_widget.py                  132      8    94%
src/ieverest/settings.py                         45      5    89%
src/ieverest/utils.py                            37      9    76%
src/ieverest/widgets/__init__.py                  4      0   100%
src/ieverest/widgets/batch_status_widget.py     140     17    88%
src/ieverest/widgets/export_data_dialog.py       36     27    25%
src/ieverest/widgets/plot_widget.py              42      2    95%
-----------------------------------------------------------------
TOTAL                                           892    171    81%

```