### PR TITLE
Simplify the configuration of everserver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ write_to = "src/everest/version.py"
 version = { attr = "everest.version.__version__" }
 
 [tool.ruff]
-src = ["everest"]
+src = ["src"]
 line-length = 88
 
 [tool.ruff.lint]

--- a/src/everest/bin/main.py
+++ b/src/everest/bin/main.py
@@ -3,8 +3,6 @@ import argparse
 import logging
 import sys
 
-from ieverest.bin.ieverest_script import ieverest_entry
-
 from everest import __version__ as everest_version
 from everest import docs
 from everest.bin.config_branch_script import config_branch_entry
@@ -17,6 +15,7 @@ from everest.bin.kill_script import kill_entry
 from everest.bin.monitor_script import monitor_entry
 from everest.bin.visualization_script import visualization_entry
 from everest.util import configure_logger
+from ieverest.bin.ieverest_script import ieverest_entry
 
 
 def _create_dump_action(dumps, extended=False):

--- a/src/everest/detached/__init__.py
+++ b/src/everest/detached/__init__.py
@@ -20,7 +20,7 @@ from everest.config_keys import ConfigKeys as CK
 from everest.simulator import JOB_FAILURE, JOB_SUCCESS, Status
 from everest.strings import (
     EVEREST,
-    EVEREST_SERVER,
+    EVEREST_SERVER_CONFIG,
     OPT_PROGRESS_ENDPOINT,
     OPT_PROGRESS_ID,
     SIM_PROGRESS_ENDPOINT,
@@ -361,7 +361,7 @@ def start_monitor(config: EverestConfig, callback, polling_interval=5):
 
 
 _EVERSERVER_JOB_PATH = pkg_resources.resource_filename(
-    "everest.detached", os.path.join("jobs", EVEREST_SERVER)
+    "everest.detached", os.path.join("jobs", EVEREST_SERVER_CONFIG)
 )
 
 _QUEUE_SYSTEMS: Mapping[Literal["LSF", "SLURM"], dict] = {
@@ -478,19 +478,19 @@ def generate_everserver_ert_config(config: EverestConfig, debug_mode: bool = Fal
     everserver_config.update(
         {
             "RUNPATH": simulation_path,
-            "JOBNAME": EVEREST_SERVER,
+            "JOBNAME": EVEREST_SERVER_CONFIG,
             "NUM_REALIZATIONS": 1,
             "MAX_SUBMIT": 1,
-            "ENSPATH": os.path.join(detached_node_dir, EVEREST_SERVER),
+            "ENSPATH": os.path.join(detached_node_dir, EVEREST_SERVER_CONFIG),
             "RUNPATH_FILE": os.path.join(detached_node_dir, ".res_runpath_list"),
         }
     )
     install_job = everserver_config.get("INSTALL_JOB", [])
-    install_job.append((EVEREST_SERVER, _EVERSERVER_JOB_PATH))
+    install_job.append((EVEREST_SERVER_CONFIG, _EVERSERVER_JOB_PATH))
     everserver_config["INSTALL_JOB"] = install_job
 
     simulation_job = everserver_config.get("SIMULATION_JOB", [])
-    simulation_job.append([EVEREST_SERVER] + arg_list)
+    simulation_job.append([EVEREST_SERVER_CONFIG] + arg_list)
     everserver_config["SIMULATION_JOB"] = simulation_job
 
     if queue_system in _QUEUE_SYSTEMS:

--- a/src/everest/detached/jobs/everserver.py
+++ b/src/everest/detached/jobs/everserver.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python
 import argparse
 import json
 import logging
 import os
 import socket
 import ssl
-import sys
 import threading
 import traceback
 from base64 import b64encode
@@ -218,11 +216,11 @@ def _configure_loggers(config: EverestConfig):
     )
 
 
-def main(args):
+def main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument("--config-file", type=str)
     arg_parser.add_argument("--debug", action="store_true")
-    options, _ = arg_parser.parse_known_args(args=args)
+    options = arg_parser.parse_args()
     config = EverestConfig.load_file(options.config_file)
     if options.debug:
         config.logging_level = "debug"
@@ -411,7 +409,3 @@ def _generate_authentication():
     n_bytes = 128
     random_bytes = bytes(os.urandom(n_bytes))
     return b64encode(random_bytes).decode("utf-8")
-
-
-if __name__ == "__main__":
-    main(sys.argv[1:])

--- a/src/everest/detached/jobs/everserver_config
+++ b/src/everest/detached/jobs/everserver_config
@@ -1,4 +1,4 @@
-EXECUTABLE  everserver.py
+EXECUTABLE  everserver
 
 STDOUT ../../logs/everest_server.stdout
 STDERR ../../logs/everest_server.stderr

--- a/src/everest/strings.py
+++ b/src/everest/strings.py
@@ -5,7 +5,7 @@ DETACHED_NODE_DIR = "detached_node_output"
 DEFAULT_OUTPUT_DIR = "everest_output"
 DEFAULT_LOGGING_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
 
-EVEREST_SERVER = "everserver"
+EVEREST_SERVER_CONFIG = "everserver_config"
 EVEREST = "everest"
 
 HOSTFILE_NAME = "hostfile"

--- a/src/ieverest/bin/ieverest_script.py
+++ b/src/ieverest/bin/ieverest_script.py
@@ -4,10 +4,10 @@ import logging
 import sys
 from argparse import ArgumentParser
 
-from everest.util import version_info
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication
 
+from everest.util import version_info
 from ieverest import IEverest
 
 

--- a/src/ieverest/config_widget.py
+++ b/src/ieverest/config_widget.py
@@ -1,9 +1,9 @@
 from io import StringIO
 
-from everest.config import EverestConfig
 from qtpy.QtWidgets import QWidget
 from ruamel.yaml import YAML
 
+from everest.config import EverestConfig
 from ieverest import utils
 
 

--- a/src/ieverest/ieverest.py
+++ b/src/ieverest/ieverest.py
@@ -1,5 +1,9 @@
 from ert.config import ErtConfig
 from ert.storage import open_storage
+from pydantic import ValidationError
+from qtpy.QtCore import QObject, QThread, Signal
+from qtpy.QtWidgets import QFileDialog, QMessageBox, qApp
+
 from everest.config import EverestConfig, validation_utils
 from everest.detached import (
     ServerStatus,
@@ -19,10 +23,6 @@ from everest.plugins.site_config_env import PluginSiteConfigEnv
 from everest.simulator import Status
 from everest.strings import OPT_PROGRESS_ID, SIM_PROGRESS_ID
 from everest.util import configure_logger, makedirs_if_needed
-from pydantic import ValidationError
-from qtpy.QtCore import QObject, QThread, Signal
-from qtpy.QtWidgets import QFileDialog, QMessageBox, qApp
-
 from ieverest import settings
 from ieverest.io import QtDialogsOut, QtStatusBarOut
 from ieverest.main_window import MainWindow

--- a/src/ieverest/main_window.py
+++ b/src/ieverest/main_window.py
@@ -1,7 +1,5 @@
 from functools import partial
 
-from everest import __version__ as everest_version
-from everest.config import EverestConfig
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
@@ -15,6 +13,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from everest import __version__ as everest_version
+from everest.config import EverestConfig
 from ieverest.config_widget import ConfigWidget
 from ieverest.monitor_widget import MonitorWidget
 from ieverest.utils import load_ui

--- a/src/ieverest/monitor_widget.py
+++ b/src/ieverest/monitor_widget.py
@@ -2,11 +2,11 @@ from typing import Optional
 
 import pandas as pd
 from dateutil import parser
-from everest.config import EverestConfig
-from everest.simulator import JOB_FAILURE, JOB_SUCCESS
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QComboBox, QVBoxLayout, QWidget
 
+from everest.config import EverestConfig
+from everest.simulator import JOB_FAILURE, JOB_SUCCESS
 from ieverest.utils import load_ui, remove_layout_item
 from ieverest.widgets import BatchStatusWidget, PlotWidget
 from ieverest.widgets.batch_status_widget import get_job_status

--- a/src/ieverest/widgets/batch_status_widget.py
+++ b/src/ieverest/widgets/batch_status_widget.py
@@ -1,8 +1,8 @@
-from everest.simulator import JOB_FAILURE, JOB_RUNNING, JOB_SUCCESS, JOB_WAITING
 from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QIcon, QPixmap
 from qtpy.QtWidgets import QLabel, QSizePolicy, QSpacerItem, QStyle, QWidget, qApp
 
+from everest.simulator import JOB_FAILURE, JOB_RUNNING, JOB_SUCCESS, JOB_WAITING
 from ieverest.utils import load_ui
 
 

--- a/src/ieverest/widgets/export_data_dialog.py
+++ b/src/ieverest/widgets/export_data_dialog.py
@@ -1,10 +1,10 @@
 import os
 
+from qtpy.QtWidgets import QDialog, QFileDialog
+
 from everest.config import EverestConfig
 from everest.config.export_config import ExportConfig
 from everest.export import export
-from qtpy.QtWidgets import QDialog, QFileDialog
-
 from ieverest.utils import APP_OUT_DIALOGS, APP_OUT_STATUS_BAR, app_output, load_ui
 
 

--- a/tests/everest/conftest.py
+++ b/tests/everest/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Callable, Dict, Iterator, Optional, Union
 
 import pytest
+
 from everest.config.control_config import ControlConfig
 
 

--- a/tests/everest/entry_points/test_config_branch_entry.py
+++ b/tests/everest/entry_points/test_config_branch_entry.py
@@ -2,12 +2,12 @@ import difflib
 from os.path import exists
 from unittest.mock import PropertyMock, patch
 
+from seba_sqlite.snapshot import SebaSnapshot
+
 from everest.bin.config_branch_script import config_branch_entry
 from everest.config import EverestConfig
 from everest.config_file_loader import load_yaml
 from everest.config_keys import ConfigKeys as CK
-from seba_sqlite.snapshot import SebaSnapshot
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/entry_points/test_everest_entry.py
+++ b/tests/everest/entry_points/test_everest_entry.py
@@ -4,6 +4,7 @@ from functools import partial
 from unittest.mock import PropertyMock, patch
 
 import pytest
+
 from everest.bin.everest_script import everest_entry
 from everest.bin.kill_script import kill_entry
 from everest.bin.monitor_script import monitor_entry
@@ -17,7 +18,6 @@ from everest.detached import (
 from everest.jobs import shell_commands
 from everest.simulator import JOB_SUCCESS
 from ieverest.bin.ieverest_script import ieverest_entry
-
 from tests.everest.utils import capture_streams, relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/entry_points/test_everexport.py
+++ b/tests/everest/entry_points/test_everexport.py
@@ -5,12 +5,12 @@ from unittest.mock import patch
 
 import pandas as pd
 import pytest
+
 from everest import ConfigKeys as CK
 from everest import MetaDataColumnNames as MDCN
 from everest.bin.everexport_script import everexport_entry
 from everest.bin.utils import ProgressBar
 from everest.config import EverestConfig
-
 from tests.everest.utils import (
     create_cached_mocked_test_case,
     relpath,

--- a/tests/everest/entry_points/test_visualization_entry.py
+++ b/tests/everest/entry_points/test_visualization_entry.py
@@ -2,10 +2,10 @@ import sys
 from unittest.mock import PropertyMock, patch
 
 import pytest
+
 from everest.bin.visualization_script import visualization_entry
 from everest.config import EverestConfig
 from everest.detached import ServerStatus
-
 from tests.everest.utils import capture_streams, relpath
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func", "config_advanced.yml")

--- a/tests/everest/functional/test_main_everest_entry.py
+++ b/tests/everest/functional/test_main_everest_entry.py
@@ -2,6 +2,15 @@ import os
 from textwrap import dedent
 
 import pytest
+from ruamel.yaml import YAML
+from seba_sqlite.snapshot import SebaSnapshot
+from tests.everest.utils import (
+    capture_streams,
+    relpath,
+    skipif_no_everest_models,
+    tmpdir,
+)
+
 from everest import __version__ as everest_version
 from everest.bin.main import start_everest
 from everest.config import EverestConfig
@@ -10,14 +19,6 @@ from everest.detached import (
     context_stop_and_wait,
     everserver_status,
     wait_for_context,
-)
-from ruamel.yaml import YAML
-from seba_sqlite.snapshot import SebaSnapshot
-from tests.everest.utils import (
-    capture_streams,
-    relpath,
-    skipif_no_everest_models,
-    tmpdir,
 )
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/functional/test_ui.py
+++ b/tests/everest/functional/test_ui.py
@@ -1,4 +1,10 @@
 import pytest
+from PyQt5.QtWidgets import QAction, QPushButton, QWidget
+from qtpy.QtCore import Qt
+from seba_sqlite.snapshot import SebaSnapshot
+from tests.everest.dialogs_mocker import mock_dialogs_all
+from tests.everest.utils import relpath, tmpdir
+
 from everest.config import EverestConfig
 from everest.detached import (
     ServerStatus,
@@ -7,11 +13,6 @@ from everest.detached import (
     wait_for_context,
 )
 from ieverest import IEverest
-from PyQt5.QtWidgets import QAction, QPushButton, QWidget
-from qtpy.QtCore import Qt
-from seba_sqlite.snapshot import SebaSnapshot
-from tests.everest.dialogs_mocker import mock_dialogs_all
-from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")
 CONFIG_FILE_MINIMAL = "config_minimal.yml"

--- a/tests/everest/test_api.py
+++ b/tests/everest/test_api.py
@@ -3,13 +3,13 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pandas as pd
 import pytest
-from everest.api import EverestDataAPI
-from everest.config import EverestConfig
-from everest.detached import ServerStatus
 from pandas import Timestamp
 from seba_sqlite.database import ControlDefinition, Function
 from seba_sqlite.snapshot import Metadata, OptimizationInfo, SimulationInfo, Snapshot
 
+from everest.api import EverestDataAPI
+from everest.config import EverestConfig
+from everest.detached import ServerStatus
 from tests.everest.utils import relpath, tmpdir
 
 # Global values used to create the mock snapshot.

--- a/tests/everest/test_cache.py
+++ b/tests/everest/test_cache.py
@@ -1,8 +1,8 @@
 import numpy as np
+
 from everest.config import EverestConfig
 from everest.simulator import Simulator
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, tmp
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_config_branch.py
+++ b/tests/everest/test_config_branch.py
@@ -1,11 +1,11 @@
 import pytest
+
 from everest.bin.config_branch_script import (
     _updated_initial_guess,
     opt_controls_by_batch,
 )
 from everest.config_file_loader import load_yaml
 from everest.config_keys import ConfigKeys as CK
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_config_file_loader.py
+++ b/tests/everest/test_config_file_loader.py
@@ -3,12 +3,12 @@ import string
 from unittest.mock import patch
 
 import pytest
-from everest import ConfigKeys as CK
-from everest import config_file_loader as loader
-from everest.config import EverestConfig
 from pydantic_core import ValidationError
 from ruamel.yaml import YAML
 
+from everest import ConfigKeys as CK
+from everest import config_file_loader as loader
+from everest.config import EverestConfig
 from tests.everest.utils import relpath, tmpdir
 
 mocked_root = relpath(os.path.join("test_data", "mocked_test_case"))

--- a/tests/everest/test_config_validation.py
+++ b/tests/everest/test_config_validation.py
@@ -5,11 +5,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Union
 
 import pytest
+from pydantic import ValidationError
+
 from everest.config import EverestConfig, ModelConfig
 from everest.config.control_variable_config import ControlVariableConfig
 from everest.config.sampler_config import SamplerConfig
-from pydantic import ValidationError
-
 from tests.everest.utils import tmpdir
 
 

--- a/tests/everest/test_controls.py
+++ b/tests/everest/test_controls.py
@@ -5,6 +5,8 @@ from copy import deepcopy
 from typing import List
 
 import pytest
+from pydantic import ValidationError
+
 from everest import ConfigKeys
 from everest.config import EverestConfig
 from everest.config.control_config import ControlConfig
@@ -14,8 +16,6 @@ from everest.config.control_variable_config import (
 )
 from everest.config.input_constraint_config import InputConstraintConfig
 from everest.config.well_config import WellConfig
-from pydantic import ValidationError
-
 from tests.everest.utils import relpath, tmp, tmpdir
 
 cfg_dir = relpath("test_data", "mocked_test_case")

--- a/tests/everest/test_cvar.py
+++ b/tests/everest/test_cvar.py
@@ -1,7 +1,7 @@
 import pytest
+
 from everest.config import EverestConfig
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -33,7 +33,7 @@ from everest.simulator.everest_to_ert import everest_to_ert_config
 from everest.strings import (
     DEFAULT_OUTPUT_DIR,
     DETACHED_NODE_DIR,
-    EVEREST_SERVER,
+    EVEREST_SERVER_CONFIG,
     SIMULATION_DIR,
 )
 from everest.util import makedirs_if_needed
@@ -190,9 +190,9 @@ def _get_reference_config():
     cwd = os.getcwd()
     reference_config.update(
         {
-            "INSTALL_JOB": [(EVEREST_SERVER, _EVERSERVER_JOB_PATH)],
+            "INSTALL_JOB": [(EVEREST_SERVER_CONFIG, _EVERSERVER_JOB_PATH)],
             "QUEUE_SYSTEM": "LOCAL",
-            "JOBNAME": EVEREST_SERVER,
+            "JOBNAME": EVEREST_SERVER_CONFIG,
             "MAX_SUBMIT": 1,
             "NUM_REALIZATIONS": 1,
             "RUNPATH": os.path.join(
@@ -203,13 +203,13 @@ def _get_reference_config():
             ),
             "SIMULATION_JOB": [
                 [
-                    EVEREST_SERVER,
+                    EVEREST_SERVER_CONFIG,
                     "--config-file",
                     os.path.join(cwd, "config_minimal.yml"),
                 ],
             ],
             "ENSPATH": os.path.join(
-                cwd, DEFAULT_OUTPUT_DIR, DETACHED_NODE_DIR, EVEREST_SERVER
+                cwd, DEFAULT_OUTPUT_DIR, DETACHED_NODE_DIR, EVEREST_SERVER_CONFIG
             ),
             "RUNPATH_FILE": os.path.join(
                 cwd, DEFAULT_OUTPUT_DIR, DETACHED_NODE_DIR, ".res_runpath_list"

--- a/tests/everest/test_detached.py
+++ b/tests/everest/test_detached.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 from ert.config import ErtConfig, QueueSystem
 from ert.storage import open_storage
+
 from everest.config import EverestConfig
 from everest.config.server_config import ServerConfig
 from everest.config.simulator_config import SimulatorConfig
@@ -36,7 +37,6 @@ from everest.strings import (
     SIMULATION_DIR,
 )
 from everest.util import makedirs_if_needed
-
 from tests.everest.utils import relpath, tmpdir
 
 

--- a/tests/everest/test_discrete.py
+++ b/tests/everest/test_discrete.py
@@ -1,6 +1,5 @@
 from everest.config import EverestConfig
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_egg_simulation.py
+++ b/tests/everest/test_egg_simulation.py
@@ -2,16 +2,16 @@ import json
 import os
 import shutil
 
-import everest
 import pytest
 from ert.config import ErtConfig, QueueSystem
+
+import everest
 from everest.config import EverestConfig
 from everest.config.export_config import ExportConfig
 from everest.config_keys import ConfigKeys
 from everest.export import MetaDataColumnNames
 from everest.plugins.site_config_env import PluginSiteConfigEnv
 from everest.simulator.everest_to_ert import everest_to_ert_config
-
 from tests.everest.utils import (
     everest_default_jobs,
     hide_opm,

--- a/tests/everest/test_environment.py
+++ b/tests/everest/test_environment.py
@@ -1,10 +1,10 @@
 import os
 
-import everest
 import pytest
+
+import everest
 from everest.config import EverestConfig
 from everest.simulator.everest_to_ert import everest_to_ert_config
-
 from tests.everest.utils import relpath, tmpdir
 
 root = os.path.join("..", "..", "examples", "math_func")

--- a/tests/everest/test_everest_initialization.py
+++ b/tests/everest/test_everest_initialization.py
@@ -1,9 +1,9 @@
 import os
 
 import pytest
+
 from everest.config import EverestConfig
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, tmp
 
 NO_PROJECT_RES = (

--- a/tests/everest/test_everest_output.py
+++ b/tests/everest/test_everest_output.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from ert.config import ErtConfig
 from ert.storage import open_storage
+
 from everest.config import EverestConfig
 from everest.detached import generate_everserver_ert_config, start_server
 from everest.strings import (
@@ -15,7 +16,6 @@ from everest.strings import (
 )
 from everest.suite import _EverestWorkflow
 from everest.util import makedirs_if_needed
-
 from tests.everest.utils import relpath, tmpdir
 
 

--- a/tests/everest/test_everjobs_io.py
+++ b/tests/everest/test_everjobs_io.py
@@ -1,10 +1,10 @@
 import json
 import os
 
-import everest
 import pytest
 from ruamel.yaml import YAML
 
+import everest
 from tests.everest.utils import tmpdir
 
 

--- a/tests/everest/test_everlint.py
+++ b/tests/everest/test_everlint.py
@@ -2,13 +2,13 @@ import os
 import tempfile
 from pathlib import Path
 
-import everest
 import pytest
+
+import everest
 from everest import ConfigKeys
 from everest.config import EverestConfig
 from everest.config_file_loader import yaml_file_to_substituted_config_dict
 from everest.util.forward_models import collect_forward_models
-
 from tests.everest.test_config_validation import has_error
 from tests.everest.utils import relpath
 

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -3,14 +3,14 @@ import ssl
 from functools import partial
 from unittest.mock import patch
 
+from ropt.enums import OptimizerExitCode
+from seba_sqlite.snapshot import SebaSnapshot
+
 from everest.config import EverestConfig
 from everest.detached import ServerStatus, everserver_status
 from everest.detached.jobs import everserver
 from everest.simulator import JOB_FAILURE, JOB_SUCCESS
 from everest.strings import OPT_FAILURE_REALIZATIONS, SIM_PROGRESS_ENDPOINT
-from ropt.enums import OptimizerExitCode
-from seba_sqlite.snapshot import SebaSnapshot
-
 from tests.everest.utils import relpath, tmpdir
 
 

--- a/tests/everest/test_everserver.py
+++ b/tests/everest/test_everserver.py
@@ -80,6 +80,7 @@ def test_hostfile_storage():
     assert result == expected_result
 
 
+@patch("sys.argv", ["name", "--config-file", "config_minimal.yml"])
 @patch(
     "everest.detached.jobs.everserver.configure_logger",
     side_effect=configure_everserver_logger,
@@ -88,13 +89,14 @@ def test_hostfile_storage():
 def test_everserver_status_failure(mf_1):
     config_file = "config_minimal.yml"
     config = EverestConfig.load_file(config_file)
-    everserver.main(["--config-file", config_file])
+    everserver.main()
     status = everserver_status(config)
 
     assert status["status"] == ServerStatus.failed
     assert "Exception: Configuring logger failed" in status["message"]
 
 
+@patch("sys.argv", ["name", "--config-file", "config_minimal.yml"])
 @patch("everest.detached.jobs.everserver.configure_logger")
 @patch("everest.detached.jobs.everserver._generate_authentication")
 @patch(
@@ -123,13 +125,14 @@ def test_everserver_status_failure(mf_1):
 def test_everserver_status_running_complete(*args):
     config_file = "config_minimal.yml"
     config = EverestConfig.load_file(config_file)
-    everserver.main(["--config-file", config_file])
+    everserver.main()
     status = everserver_status(config)
 
     assert status["status"] == ServerStatus.completed
     assert status["message"] == "Optimization completed."
 
 
+@patch("sys.argv", ["name", "--config-file", "config_minimal.yml"])
 @patch("everest.detached.jobs.everserver.configure_logger")
 @patch("everest.detached.jobs.everserver._generate_authentication")
 @patch(
@@ -166,7 +169,7 @@ def test_everserver_status_running_complete(*args):
 def test_everserver_status_failed_job(*args):
     config_file = "config_minimal.yml"
     config = EverestConfig.load_file(config_file)
-    everserver.main(["--config-file", config_file])
+    everserver.main()
     status = everserver_status(config)
 
     # The server should fail and store a user-friendly message.
@@ -175,6 +178,7 @@ def test_everserver_status_failed_job(*args):
     assert "3 job failures caused by: job1, job2" in status["message"]
 
 
+@patch("sys.argv", ["name", "--config-file", "config_minimal.yml"])
 @patch("everest.detached.jobs.everserver.configure_logger")
 @patch("everest.detached.jobs.everserver._generate_authentication")
 @patch(
@@ -199,7 +203,7 @@ def test_everserver_status_failed_job(*args):
 def test_everserver_status_exception(*args):
     config_file = "config_minimal.yml"
     config = EverestConfig.load_file(config_file)
-    everserver.main(["--config-file", config_file])
+    everserver.main()
     status = everserver_status(config)
 
     # The server should fail, and store the exception that
@@ -208,6 +212,7 @@ def test_everserver_status_exception(*args):
     assert "Exception: Failed optimization" in status["message"]
 
 
+@patch("sys.argv", ["name", "--config-file", "config_one_batch.yml"])
 @patch("everest.detached.jobs.everserver.configure_logger")
 @patch("everest.detached.jobs.everserver._generate_authentication")
 @patch(
@@ -228,7 +233,7 @@ def test_everserver_status_exception(*args):
 def test_everserver_status_max_batch_num(*args):
     config_file = "config_one_batch.yml"
     config = EverestConfig.load_file(config_file)
-    everserver.main(["--config-file", config_file])
+    everserver.main()
     status = everserver_status(config)
 
     # The server should complete without error.

--- a/tests/everest/test_export.py
+++ b/tests/everest/test_export.py
@@ -3,12 +3,12 @@ import shutil
 
 import pandas as pd
 import pytest
+
 from everest import filter_data
 from everest.bin.utils import export_with_progress
 from everest.config import EverestConfig
 from everest.config.export_config import ExportConfig
 from everest.export import export, validate_export
-
 from tests.everest.utils import create_cached_mocked_test_case, relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_export_data_dialog.py
+++ b/tests/everest/test_export_data_dialog.py
@@ -2,12 +2,12 @@ import os
 from pathlib import Path
 
 import pytest
-from everest.config.everest_config import EverestConfig
-from ieverest import IEverest
-from ieverest.widgets.export_data_dialog import ExportDataDialog
 from PyQt5.QtWidgets import QFileDialog, QMessageBox
 from qtpy.QtCore import Qt, QTimer
 
+from everest.config.everest_config import EverestConfig
+from ieverest import IEverest
+from ieverest.widgets.export_data_dialog import ExportDataDialog
 from tests.everest.utils import tmpdir
 
 

--- a/tests/everest/test_fix_control.py
+++ b/tests/everest/test_fix_control.py
@@ -1,6 +1,5 @@
 from everest.config import EverestConfig
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_fm_plugins.py
+++ b/tests/everest/test_fm_plugins.py
@@ -4,10 +4,11 @@ from typing import Callable, Iterator, Sequence, Type
 
 import pluggy
 import pytest
+from pydantic import BaseModel
+
 from everest.plugins import hook_impl, hook_specs, hookimpl
 from everest.strings import EVEREST
 from everest.util.forward_models import collect_forward_models
-from pydantic import BaseModel
 
 
 class MockPluginManager(pluggy.PluginManager):

--- a/tests/everest/test_input_constraints_config.py
+++ b/tests/everest/test_input_constraints_config.py
@@ -1,6 +1,5 @@
 from everest import ConfigKeys
 from everest.config import EverestConfig
-
 from tests.everest.utils import relpath
 
 

--- a/tests/everest/test_logging.py
+++ b/tests/everest/test_logging.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from ert.config import ErtConfig
 from ert.storage import open_storage
+
 from everest.config import EverestConfig
 from everest.detached import (
     context_stop_and_wait,
@@ -12,7 +13,6 @@ from everest.detached import (
     wait_for_server,
 )
 from everest.util import makedirs_if_needed
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_math_func.py
+++ b/tests/everest/test_math_func.py
@@ -4,13 +4,13 @@ import os
 import numpy as np
 import pandas as pd
 import pytest
+
 from everest import ConfigKeys as CK
 from everest.config import EverestConfig
 from everest.config.export_config import ExportConfig
 from everest.export import export
 from everest.suite import _EverestWorkflow
 from everest.util import makedirs_if_needed
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_multiobjective.py
+++ b/tests/everest/test_multiobjective.py
@@ -1,11 +1,11 @@
 import pytest
 from ert.config import ErtConfig
+from ropt.config.enopt import EnOptConfig
+
 from everest.config import EverestConfig
 from everest.optimizer.everest2ropt import everest2ropt
 from everest.simulator.everest_to_ert import everest_to_ert_config
 from everest.suite import _EverestWorkflow
-from ropt.config.enopt import EnOptConfig
-
 from tests.everest.test_config_validation import has_error
 from tests.everest.utils import relpath, tmpdir
 

--- a/tests/everest/test_objective_type.py
+++ b/tests/everest/test_objective_type.py
@@ -1,7 +1,7 @@
 import pytest
+
 from everest.config import EverestConfig
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_optimization_config.py
+++ b/tests/everest/test_optimization_config.py
@@ -1,8 +1,8 @@
 import os
 
 import pytest
-from everest.config import EverestConfig
 
+from everest.config import EverestConfig
 from tests.everest.utils import relpath, tmpdir
 
 

--- a/tests/everest/test_output_constraints.py
+++ b/tests/everest/test_output_constraints.py
@@ -1,12 +1,13 @@
 import os
 
 import pytest
+from ropt.config.enopt import EnOptConfig
+from ropt.enums import ConstraintType
+
 from everest import ConfigKeys
 from everest.config import EverestConfig
 from everest.optimizer.everest2ropt import everest2ropt
 from everest.suite import _EverestWorkflow
-from ropt.config.enopt import EnOptConfig
-from ropt.enums import ConstraintType
 
 from .test_config_validation import has_error
 from .utils import relpath, tmpdir

--- a/tests/everest/test_qt_dialogs_output.py
+++ b/tests/everest/test_qt_dialogs_output.py
@@ -1,12 +1,13 @@
 import pytest
+from PyQt5.QtWidgets import QMessageBox
+from qtpy.QtCore import Qt, QTimer
+
 from everest.detached import (
     context_stop_and_wait,
     wait_for_context,
 )
 from ieverest import IEverest
 from ieverest.utils import APP_OUT_DIALOGS, app_output
-from PyQt5.QtWidgets import QMessageBox
-from qtpy.QtCore import Qt, QTimer
 
 
 @pytest.mark.ui_test

--- a/tests/everest/test_queue_driver.py
+++ b/tests/everest/test_queue_driver.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+
 from everest.config import EverestConfig
 from everest.queue_driver import queue_driver
 from everest.queue_driver.queue_driver import _extract_queue_system

--- a/tests/everest/test_repo_configs.py
+++ b/tests/everest/test_repo_configs.py
@@ -1,8 +1,9 @@
 import os
 
+from ropt.exceptions import ConfigError as ROptConfigError
+
 from everest.config_file_loader import yaml_file_to_substituted_config_dict
 from everest.optimizer.utils import get_ropt_plugin_manager
-from ropt.exceptions import ConfigError as ROptConfigError
 
 
 def _get_all_files(folder):

--- a/tests/everest/test_res_initialization.py
+++ b/tests/everest/test_res_initialization.py
@@ -2,9 +2,10 @@ import itertools
 import os
 from unittest.mock import patch
 
-import everest
 import pytest
 from ert.config import ErtConfig
+
+import everest
 from everest import ConfigKeys
 from everest.config import EverestConfig
 from everest.config.install_data_config import InstallDataConfig
@@ -13,7 +14,6 @@ from everest.config.well_config import WellConfig
 from everest.config.workflow_config import WorkflowConfig
 from everest.simulator.everest_to_ert import everest_to_ert_config
 from everest.util.forward_models import collect_forward_models
-
 from tests.everest.utils import (
     everest_default_jobs,
     hide_opm,

--- a/tests/everest/test_restart.py
+++ b/tests/everest/test_restart.py
@@ -1,7 +1,7 @@
 import pytest
+
 from everest.config import EverestConfig
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_samplers.py
+++ b/tests/everest/test_samplers.py
@@ -1,8 +1,8 @@
 import pytest
+
 from everest.config import EverestConfig
 from everest.config.sampler_config import SamplerConfig
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, tmpdir
 
 CONFIG_PATH = relpath("..", "..", "examples", "math_func")

--- a/tests/everest/test_seba_initialization.py
+++ b/tests/everest/test_seba_initialization.py
@@ -2,13 +2,13 @@ import os.path
 
 import numpy
 import pytest
-from everest.config import EverestConfig
-from everest.config_file_loader import yaml_file_to_substituted_config_dict
-from everest.optimizer.everest2ropt import everest2ropt
 from pydantic import ValidationError
 from ropt.config.enopt import EnOptConfig
 from ropt.enums import ConstraintType
 
+from everest.config import EverestConfig
+from everest.config_file_loader import yaml_file_to_substituted_config_dict
+from everest.optimizer.everest2ropt import everest2ropt
 from tests.everest.utils import relpath, tmpdir
 
 _CONFIG_DIR = relpath("test_data/mocked_test_case")

--- a/tests/everest/test_shell_scripts.py
+++ b/tests/everest/test_shell_scripts.py
@@ -1,6 +1,5 @@
 from everest.config.everest_config import EverestConfig, get_system_installed_jobs
 from everest.jobs import shell_commands
-
 from tests.everest.utils import relpath
 
 

--- a/tests/everest/test_site_config_env.py
+++ b/tests/everest/test_site_config_env.py
@@ -3,6 +3,7 @@ import shutil
 from unittest.mock import patch
 
 import pytest
+
 from everest.plugins import hook_impl as everest_implementation
 from everest.plugins import hookimpl
 from everest.plugins.hook_manager import EverestPluginManager

--- a/tests/everest/test_templating.py
+++ b/tests/everest/test_templating.py
@@ -2,11 +2,11 @@ import json
 import os
 import subprocess
 
-import everest
 import pytest
-from everest.config import EverestConfig
 from ruamel.yaml import YAML
 
+import everest
+from everest.config import EverestConfig
 from tests.everest.utils import relpath, tmpdir
 
 TMPL_TEST_PATH = os.path.join("test_data", "templating")

--- a/tests/everest/test_ui_run.py
+++ b/tests/everest/test_ui_run.py
@@ -1,7 +1,7 @@
 import pytest
-from ieverest import IEverest
 from qtpy.QtCore import Qt
 
+from ieverest import IEverest
 from tests.everest.dialogs_mocker import mock_dialogs_all
 from tests.everest.utils import relpath, tmpdir
 

--- a/tests/everest/test_util.py
+++ b/tests/everest/test_util.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
 from everest import util
 from everest.bin.utils import report_on_previous_run
 from everest.config import EverestConfig
@@ -10,7 +11,6 @@ from everest.config.everest_config import get_system_installed_jobs
 from everest.config_keys import ConfigKeys
 from everest.detached import ServerStatus
 from everest.strings import SERVER_STATUS
-
 from tests.everest.utils import (
     capture_streams,
     hide_opm,

--- a/tests/everest/test_well_tools.py
+++ b/tests/everest/test_well_tools.py
@@ -2,10 +2,10 @@ import json
 import os
 import subprocess
 
-import everest
 import pytest
 from ruamel.yaml import YAML
 
+import everest
 from tests.everest.utils import tmpdir
 
 

--- a/tests/everest/test_wells.py
+++ b/tests/everest/test_wells.py
@@ -1,7 +1,7 @@
 import pytest
+
 from everest.config import EverestConfig
 from everest.config_file_loader import yaml_file_to_substituted_config_dict
-
 from tests.everest.test_config_validation import has_error
 from tests.everest.utils import relpath
 

--- a/tests/everest/test_workflows.py
+++ b/tests/everest/test_workflows.py
@@ -2,9 +2,9 @@ from pathlib import Path
 from typing import Callable, Optional
 
 import pytest
+
 from everest.config import EverestConfig
 from everest.suite import _EverestWorkflow
-
 from tests.everest.utils import relpath, skipif_no_everest_models, tmpdir
 
 CONFIG_DIR = relpath("test_data", "mocked_test_case")

--- a/tests/everest/test_yaml_parser.py
+++ b/tests/everest/test_yaml_parser.py
@@ -1,13 +1,13 @@
 import os
 from pathlib import Path
 
-import everest
 import pytest
+from ruamel.yaml import YAML
+
+import everest
 from everest import ConfigKeys
 from everest.config import EverestConfig
 from everest.simulator.everest_to_ert import everest_to_ert_config
-from ruamel.yaml import YAML
-
 from tests.everest.utils import MockParser, relpath, skipif_no_everest_models, tmpdir
 
 snake_oil_folder = relpath("test_data", "snake_oil")

--- a/tests/everest/unit/everest/bin/test_everload.py
+++ b/tests/everest/unit/everest/bin/test_everload.py
@@ -5,17 +5,18 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 from ert.config import ErtConfig
-from everest import MetaDataColumnNames as MDCN
-from everest import export
-from everest.bin.everload_script import everload_entry
-from everest.config import EverestConfig
-from everest.strings import STORAGE_DIR
 from tests.everest.utils import (
     capture_streams,
     create_cached_mocked_test_case,
     relpath,
     tmpdir,
 )
+
+from everest import MetaDataColumnNames as MDCN
+from everest import export
+from everest.bin.everload_script import everload_entry
+from everest.config import EverestConfig
+from everest.strings import STORAGE_DIR
 
 CONFIG_PATH = relpath("test_data", "mocked_test_case")
 CONFIG_FILE = "mocked_multi_batch.yml"

--- a/tests/everest/utils/__init__.py
+++ b/tests/everest/utils/__init__.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import decorator
 import pytest
+
 from everest.bin.main import start_everest
 from everest.config import EverestConfig
 from everest.detached import ServerStatus, everserver_status

--- a/tests/everest/utils/test_pydantic_doc_generation.py
+++ b/tests/everest/utils/test_pydantic_doc_generation.py
@@ -1,8 +1,8 @@
 import sys
 
 import pytest
-from everest.docs.generate_docs_from_config_spec import generate_docs_pydantic_to_rst
 
+from everest.docs.generate_docs_from_config_spec import generate_docs_pydantic_to_rst
 from tests.everest.utils import relpath
 
 


### PR DESCRIPTION
Everserver is installed as a console script, which means we dont need everserver.py to be executable. This makes it more transparent which entry point we are actually using.